### PR TITLE
Adding \value-tag recipe

### DIFF
--- a/website/_site/common.html
+++ b/website/_site/common.html
@@ -2,7 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
 
 <meta charset="utf-8">
+<<<<<<< Updated upstream
 <meta name="generator" content="quarto-1.3.433">
+=======
+<meta name="generator" content="quarto-1.4.555">
+>>>>>>> Stashed changes
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
@@ -19,6 +23,40 @@ ul.task-list li input[type="checkbox"] {
   width: 0.8em;
   margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
   vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
 }
 </style>
 
@@ -192,10 +230,13 @@ ul.task-list li input[type="checkbox"] {
     <h2 id="toc-title">On this page</h2>
    
   <ul>
-  <li><a href="#issue-1" id="toc-issue-1" class="nav-link active" data-scroll-target="#issue-1">Issue 1</a>
+  <li><a href="#missing-value-tags-in-.rd-files" id="toc-missing-value-tags-in-.rd-files" class="nav-link active" data-scroll-target="#missing-value-tags-in-.rd-files">Missing <code>\value</code>-tags in .Rd-files</a>
   <ul class="collapse">
   <li><a href="#problem" id="toc-problem" class="nav-link" data-scroll-target="#problem">Problem</a></li>
-  <li><a href="#solution" id="toc-solution" class="nav-link" data-scroll-target="#solution">Solution</a></li>
+  <li><a href="#solution" id="toc-solution" class="nav-link" data-scroll-target="#solution">Solution</a>
+  <ul class="collapse">
+  <li><a href="#details" id="toc-details" class="nav-link" data-scroll-target="#details">Details</a></li>
+  </ul></li>
   </ul></li>
   <li><a href="#issue-2" id="toc-issue-2" class="nav-link" data-scroll-target="#issue-2">Issue 2</a>
   <ul class="collapse">
@@ -230,13 +271,34 @@ ul.task-list li input[type="checkbox"] {
 
 </header>
 
+<<<<<<< Updated upstream
 <section id="issue-1" class="level1">
 <h1>Issue 1</h1>
+=======
+
+<section id="missing-value-tags-in-.rd-files" class="level1">
+<h1>Missing <code>\value</code>-tags in .Rd-files</h1>
+>>>>>>> Stashed changes
 <section id="problem" class="level2">
 <h2 class="anchored" data-anchor-id="problem">Problem</h2>
+<p>Every .Rd file should have an <code>\value</code>-tag stating what the output of the function is. Even if nothing is returned, the <code>\value</code>-tag is necessary for CRAN.</p>
 </section>
 <section id="solution" class="level2">
 <h2 class="anchored" data-anchor-id="solution">Solution</h2>
+<p>Often it is enough to simply add the missing <code>\value</code>-tags. If the function doesn’t return anything, write that as your <code>\value</code>-tag.</p>
+<section id="details" class="level3">
+<h3 class="anchored" data-anchor-id="details">Details</h3>
+<p>CRAN wants a <code>\value</code>-tag for every .Rd-file containing info about the structure of the output (class) and also what the output means. The only exception are .Rd-files for data sets, marked with the <code>\docType{data}</code>-tag.</p>
+<p>Sometimes functions don’t return one specific value but are rather called for their side effects. In that case the <code>\value</code>-tag should state this.</p>
+<div class="cell">
+<div class="sourceCode cell-code" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>\value{No return value, called <span class="cf">for</span> side effects}</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</div>
+<p>When using ‘roxygen’ to render the .Rd-files, an <code>@return</code>-tag must be added in the corresponding .R-file. This will create the <code>\value</code>-tag automatically when rendering.</p>
+<div class="cell">
+<div class="sourceCode cell-code" id="cb2"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co">#' @return What your function returns.</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</div>
+<p>For more details on ‘roxygen’ check the <a href="./occasional.html#Re-Render .Rd-files with" title="roxygen">‘roxygen’</a> section.</p>
+</section>
 </section>
 </section>
 <section id="issue-2" class="level1">
@@ -495,6 +557,10 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
 });
 </script>
 </div> <!-- /content -->
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 
 
 

--- a/website/_site/index.html
+++ b/website/_site/index.html
@@ -2,7 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
 
 <meta charset="utf-8">
+<<<<<<< Updated upstream
 <meta name="generator" content="quarto-1.3.433">
+=======
+<meta name="generator" content="quarto-1.4.555">
+>>>>>>> Stashed changes
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 

--- a/website/_site/occasional.html
+++ b/website/_site/occasional.html
@@ -2,7 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
 
 <meta charset="utf-8">
+<<<<<<< Updated upstream
 <meta name="generator" content="quarto-1.3.433">
+=======
+<meta name="generator" content="quarto-1.4.555">
+>>>>>>> Stashed changes
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
@@ -192,7 +196,7 @@ ul.task-list li input[type="checkbox"] {
     <h2 id="toc-title">On this page</h2>
    
   <ul>
-  <li><a href="#issue-1" id="toc-issue-1" class="nav-link active" data-scroll-target="#issue-1">Issue 1</a>
+  <li><a href="#re-render-.rd-files-with-roxygen" id="toc-re-render-.rd-files-with-roxygen" class="nav-link active" data-scroll-target="#re-render-.rd-files-with-roxygen">Re-Render .Rd-files with ‘Roxygen’</a>
   <ul class="collapse">
   <li><a href="#problem" id="toc-problem" class="nav-link" data-scroll-target="#problem">Problem</a></li>
   <li><a href="#solution" id="toc-solution" class="nav-link" data-scroll-target="#solution">Solution</a></li>
@@ -230,8 +234,15 @@ ul.task-list li input[type="checkbox"] {
 
 </header>
 
+<<<<<<< Updated upstream
 <section id="issue-1" class="level1">
 <h1>Issue 1</h1>
+=======
+
+<section id="re-render-.rd-files-with-roxygen" class="level1">
+<h1>Re-Render .Rd-files with ‘Roxygen’</h1>
+<p>% asds</p>
+>>>>>>> Stashed changes
 <section id="problem" class="level2">
 <h2 class="anchored" data-anchor-id="problem">Problem</h2>
 </section>
@@ -495,6 +506,10 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
 });
 </script>
 </div> <!-- /content -->
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 
 
 

--- a/website/_site/search.json
+++ b/website/_site/search.json
@@ -109,6 +109,68 @@
     "href": "about.html#steering-committee",
     "title": "About",
     "section": "",
+<<<<<<< Updated upstream
     "text": "Heather Turner (@hturner): member of the R Foundation, former R Journal Editor, maintainer of 4 CRAN packages, has run several workshops on R package development.\nBettina Grün (@bettinagruen): member of the R Foundation, Journal of Statistical Software Editor-in-Chief, former R Journal Editor, maintainer of 5 CRAN packages, manager of the two assistants on the CRAN Team working on CRAN submissions.\nGwynn Gebeyehu (@nzgwynn) data scientist, former lecturer and academic researcher, has experience of technical writing for range of audiences. R user since 2002 with package development experience."
+=======
+    "text": "Heather Turner (@hturner): member of the R Foundation, former R Journal Editor, maintainer of 4 CRAN packages, has run several workshops on R package development.\nBettina Grün (@bettinagruen): member of the R Foundation, Journal of Statistical Software Editor-in-Chief, former R Journal Editor, maintainer of 5 CRAN packages, manager of the two assistants on the CRAN Team working on CRAN submissions.\nGwynn Gebeyehu (@nzgwynn) data scientist, former lecturer and academic researcher, has experience of technical writing for range of audiences. R user since 2002 with package development experience.",
+    "crumbs": [
+      "About"
+    ]
+  },
+  {
+    "objectID": "common.html",
+    "href": "common.html",
+    "title": "Common Issues",
+    "section": "",
+    "text": "Every .Rd file should have an \\value-tag stating what the output of the function is. Even if nothing is returned, the \\value-tag is necessary for CRAN.\n\n\n\nOften it is enough to simply add the missing \\value-tags. If the function doesn’t return anything, write that as your \\value-tag.\n\n\nCRAN wants a \\value-tag for every .Rd-file containing info about the structure of the output (class) and also what the output means. The only exception are .Rd-files for data sets, marked with the \\docType{data}-tag.\nSometimes functions don’t return one specific value but are rather called for their side effects. In that case the \\value-tag should state this.\n\n\\value{No return value, called for side effects}\n\nWhen using ‘roxygen’ to render the .Rd-files, an @return-tag must be added in the corresponding .R-file. This will create the \\value-tag automatically when rendering.\n\n#' @return What your function returns.\n\nFor more details on ‘roxygen’ check the ‘roxygen’ section.",
+    "crumbs": [
+      "Common Issues",
+      "Common Issues"
+    ]
+  },
+  {
+    "objectID": "common.html#problem",
+    "href": "common.html#problem",
+    "title": "Common Issues",
+    "section": "",
+    "text": "Every .Rd file should have an \\value-tag stating what the output of the function is. Even if nothing is returned, the \\value-tag is necessary for CRAN.",
+    "crumbs": [
+      "Common Issues",
+      "Common Issues"
+    ]
+  },
+  {
+    "objectID": "common.html#solution",
+    "href": "common.html#solution",
+    "title": "Common Issues",
+    "section": "",
+    "text": "Often it is enough to simply add the missing \\value-tags. If the function doesn’t return anything, write that as your \\value-tag.\n\n\nCRAN wants a \\value-tag for every .Rd-file containing info about the structure of the output (class) and also what the output means. The only exception are .Rd-files for data sets, marked with the \\docType{data}-tag.\nSometimes functions don’t return one specific value but are rather called for their side effects. In that case the \\value-tag should state this.\n\n\\value{No return value, called for side effects}\n\nWhen using ‘roxygen’ to render the .Rd-files, an @return-tag must be added in the corresponding .R-file. This will create the \\value-tag automatically when rendering.\n\n#' @return What your function returns.\n\nFor more details on ‘roxygen’ check the ‘roxygen’ section.",
+    "crumbs": [
+      "Common Issues",
+      "Common Issues"
+    ]
+  },
+  {
+    "objectID": "common.html#details",
+    "href": "common.html#details",
+    "title": "Common Issues",
+    "section": "",
+    "text": "CRAN wants a \\value-tag for every .Rd-file containing info about the structure of the output (class) and also what the output means. The only exception are .Rd-files for data sets, marked with the \\docType{data}-tag.\nSometimes functions don’t return one specific value but are rather called for their side effects. In that case the \\value-tag should state this.\n\n\\value{No return value, called for side effects}\n\nWhen using ‘roxygen’ to render the .Rd-files, an @return-tag must be added in the corresponding .R-file. This will create the \\value-tag automatically when rendering.\n\n#' @return What your function returns.\n\nFor more details on ‘roxygen’ check the ‘roxygen’ section.",
+    "crumbs": [
+      "Common Issues",
+      "Common Issues"
+    ]
+  },
+  {
+    "objectID": "occasional.html",
+    "href": "occasional.html",
+    "title": "Occasional Issues",
+    "section": "",
+    "text": "% asds",
+    "crumbs": [
+      "Occasional Issues",
+      "Occasional Issues"
+    ]
+>>>>>>> Stashed changes
   }
 ]

--- a/website/common.qmd
+++ b/website/common.qmd
@@ -3,12 +3,34 @@ title: "Common Issues"
 editor: visual
 ---
 
-# Issue 1
+# Missing `\value`-tags in .Rd-files
 
 ## Problem
 
+Every .Rd file should have an `\value`-tag stating what the output of the function is. Even if nothing is returned, the `\value`-tag is necessary for CRAN.
+
 ## Solution
 
+Often it is enough to simply add the missing `\value`-tags. If the function doesn't return anything, write that as your `\value`-tag.
+
+### Details
+
+CRAN wants a `\value`-tag for every .Rd-file containing info about the structure of the output (class) and also what the output means. 
+The only exception are .Rd-files for data sets, marked with the `\docType{data}`-tag.
+
+Sometimes functions don't return one specific value but are rather called for their side effects. In that case the `\value`-tag should state this.
+
+```{r, eval=FALSE}
+\value{No return value, called for side effects}
+```
+
+When using 'roxygen' to render the .Rd-files, an `@return`-tag must be added in the corresponding .R-file. This will create the `\value`-tag automatically when rendering.
+
+```{r}
+#' @return What your function returns.
+```
+
+For more details on 'roxygen' check the ['roxygen'](occasional.qmd#Re-Render .Rd-files with 'roxygen') section.
 
 # Issue 2
 

--- a/website/occasional.qmd
+++ b/website/occasional.qmd
@@ -3,7 +3,8 @@ title: "Occasional Issues"
 editor: visual
 ---
 
-# Issue 1
+# Re-Render .Rd-files with 'roxygen' 
+<!-- If we change the Section name -> also change crossref in common.qmd under \value-tags --> 
 
 ## Problem
 


### PR DESCRIPTION
I created the first recipe, missing \value-tags. I changed the overall structure a bit to the following:
-Problem: Short description of the problem
-Solution: Short solution
     -) Details: More details on the solution and what the problem is about including some code examples.