### PR TITLE
a little riff on Beni's html demo from today

### DIFF
--- a/website/code_issues.qmd
+++ b/website/code_issues.qmd
@@ -1,6 +1,8 @@
 ---
 title: "Code Issues"
-editor: visual
+format: 
+  html:
+    css: style.css
 ---
 
 # Issue 1

--- a/website/description_issues.qmd
+++ b/website/description_issues.qmd
@@ -1,9 +1,11 @@
 ---
 title: "DESCRIPTION file Issues"
-editor: visual
+format: 
+  html:
+    css: style.css
 ---
 
-# Formatting Software Names
+# Formatting Software Names 
 
 ## Problem
 
@@ -26,6 +28,7 @@ Description: The goal of 'readr' is to provide a fast and friendly way to
     cleanly failing when data unexpectedly changes.
 ```
 
+---
 
 # Explaining Acronyms
 

--- a/website/docs_issues.qmd
+++ b/website/docs_issues.qmd
@@ -1,6 +1,8 @@
 ---
 title: "Manuals & Documentation Issues"
-editor: visual
+format: 
+  html:
+    css: style.css
 ---
 
 # Missing `\value`-tags in .Rd-files
@@ -35,7 +37,7 @@ When using 'roxygen' to render the .Rd-files, an `@return`-tag must be added in 
 
 For more details on 'roxygen2' check the ['roxygen2' section](#repeated-rejections-of-issues-in-manuals-if-using-roxygen2).
 
---------------------------------------------------------------
+------------------------------------------------------------------------
 
 # Repeated Rejections of Issues in Manuals If Using 'roxygen2' {#repeated-rejections-of-issues-in-manuals-if-using-roxygen2}
 

--- a/website/general_issues.qmd
+++ b/website/general_issues.qmd
@@ -1,6 +1,9 @@
 ---
 title: "General Issues"
 subtitle: "General issues and helpful notes around CRAN submission best practices."
+format: 
+  html:
+    css: style.css
 ---
 
 # tbd

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,6 @@
+hr {
+    border: none;
+    height: 5px;
+    color: blue;
+    background-color: blue;
+}


### PR DESCRIPTION
I found another way to turn your html code chunk in a quarto file into a reusable feature by leveraging a separate css file. With this change we can just write `---` for the **hr** in between each recipe. let me know what you think 😄 