### PR TITLE
Add link to CRAN policy when sending an email to CRAN

### DIFF
--- a/general_issues.qmd
+++ b/general_issues.qmd
@@ -111,5 +111,5 @@ A CRAN package should not be larger than 5 MB. Please reduce the size.
 
 # Communicating with CRAN
 
-For a smooth review process and to provide CRAN volunteers with helpful context on any issues, it’s recommended to CC `cran-submission@r-project.org` in your email communications. This way, any available team member can respond. Additionally, include any updates or explanations related to your package in the submission comments file ([cran-comments.md](https://usethis.r-lib.org/reference/use_cran_comments.html)).
+For a smooth review process and to provide CRAN volunteers with helpful context on any issues, it’s recommended to CC `cran-submission@r-project.org` in your email communications. See the rules and recommendations on the [CRAN Repository Policy](https://cran.r-project.org/web/packages/policies.html). This way, any available team member can respond. Additionally, include any updates or explanations related to your package in the submission comments file ([cran-comments.md](https://usethis.r-lib.org/reference/use_cran_comments.html)).
 


### PR DESCRIPTION
This might help some maintainers to avoid receiving an email about using html emails sent to CRAN maintainers.

This was not included on #67. I think this is key. 