### PR TITLE
Fix ORCID syntax in person()

### DIFF
--- a/description_issues.qmd
+++ b/description_issues.qmd
@@ -179,7 +179,7 @@ You can find more roles in the help documentation by running `?utils::person`. M
 
 ```{r, eval=FALSE}
 Authors@R: person("Jane", "Smith", email = "chef@cran-cookbook.com",
-  role = c("aut", "cre"), ORCID = "<USER-ORCID>")
+  role = c("aut", "cre"), comment = c(ORCID = "<USER-ORCID>"))
 ```
 
 


### PR DESCRIPTION
It doesn't seem that `person()` has an `ORCID` argument. As far as I know, the ORCID should be specified via a named vector in `comment`